### PR TITLE
fix: use correct method to generate Wireguard private key

### DIFF
--- a/cmd/siderolink-agent/siderolink.go
+++ b/cmd/siderolink-agent/siderolink.go
@@ -32,7 +32,7 @@ func sideroLink(ctx context.Context, eg *errgroup.Group, logger *zap.Logger) err
 		return fmt.Errorf("error listening for gRPC API: %w", err)
 	}
 
-	privateKey, err := wgtypes.GenerateKey()
+	privateKey, err := wgtypes.GeneratePrivateKey()
 	if err != nil {
 		return fmt.Errorf("error generating key: %w", err)
 	}


### PR DESCRIPTION
`GenerateKey` generates random 32 bytes vs. the key suitable for
Wireguard endpoint key.

Signed-off-by: Andrey Smirnov <andrey.smirnov@talos-systems.com>