### PR TITLE
feat: allow setting peer endpoint using peer event

### DIFF
--- a/pkg/wireguard/peer.go
+++ b/pkg/wireguard/peer.go
@@ -20,7 +20,8 @@ type PeerSource interface {
 type PeerEvent struct {
 	PubKey wgtypes.Key
 
-	Remove bool
+	Remove   bool
+	Endpoint string
 
 	Address netaddr.IP
 }

--- a/pkg/wireguard/wireguard.go
+++ b/pkg/wireguard/wireguard.go
@@ -232,6 +232,15 @@ func (dev *Device) handlePeerEvent(logger *zap.Logger, peerEvent PeerEvent) erro
 			*netaddr.IPPrefixFrom(peerEvent.Address, peerEvent.Address.BitLen()).IPNet(),
 		}
 
+		if peerEvent.Endpoint != "" {
+			ip, err := netaddr.ParseIPPort(peerEvent.Endpoint)
+			if err != nil {
+				return fmt.Errorf("failed to parse last endpoint: %w", err)
+			}
+
+			cfg.Peers[0].Endpoint = ip.UDPAddr()
+		}
+
 		logger.Info("updating peer", zap.Stringer("public_key", peerEvent.PubKey), zap.Stringer("address", peerEvent.Address))
 	} else {
 		logger.Info("removing peer", zap.Stringer("public_key", peerEvent.PubKey))


### PR DESCRIPTION
With this change it will be possible to recover wireguard connection
immediately after the siderolink server is restarted, instead of waiting
for the client to send keep alive packet.

Signed-off-by: Artem Chernyshev <artem.chernyshev@talos-systems.com>