### PR TITLE
feat: use kernel wireguard implementation when available

### DIFF
--- a/cmd/siderolink-agent/main.go
+++ b/cmd/siderolink-agent/main.go
@@ -21,6 +21,7 @@ func main() {
 	flag.StringVar(&sideroLinkFlags.wireguardEndpoint, "sidero-link-wireguard-endpoint", "172.20.0.1:51821", "advertised Wireguard endpoint")
 	flag.StringVar(&sideroLinkFlags.apiEndpoint, "sidero-link-api-endpoint", ":4000", "gRPC API endpoint for the SideroLink")
 	flag.StringVar(&sideroLinkFlags.joinToken, "sidero-link-join-token", "", "join token")
+	flag.BoolVar(&sideroLinkFlags.forceUserspace, "sidero-link-force-userspace", false, "force usage of userspace UDP device for Wireguard")
 	flag.StringVar(&eventSinkFlags.apiEndpoint, "event-sink-endpoint", ":8080", "gRPC API endpoint for the Event Sink")
 	flag.StringVar(&logReceiverFlags.endpoint, "log-receiver-endpoint", ":4001", "TCP log receiver endpoint")
 	flag.Parse()

--- a/pkg/wireguard/interface_darwin.go
+++ b/pkg/wireguard/interface_darwin.go
@@ -1,0 +1,39 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+//go:build darwin
+
+package wireguard
+
+import (
+	"fmt"
+	"net"
+	"os/exec"
+)
+
+// darwin requires tun devices to have the name utun[0-9]+ or just utun for the kernel to select one automatically.
+// See https://github.com/WireGuard/wireguard-go/blob/master/README.md#macos for more details.
+const interfaceName = "utun"
+
+func linkUp(iface *net.Interface) error {
+	return exec.Command("ifconfig", iface.Name, "up").Run()
+}
+
+func addIPToInterface(iface *net.Interface, ipNet *net.IPNet) error {
+	isv6 := ipNet.IP.To4() == nil
+
+	inet := "inet"
+	if isv6 {
+		inet = "inet6"
+	}
+
+	cmdAndArgs := []string{"ifconfig", iface.Name, inet, ipNet.String()}
+
+	err := exec.Command(cmdAndArgs[0], cmdAndArgs[1:]...).Run()
+	if err != nil {
+		return fmt.Errorf("error running command %q: %w", cmdAndArgs, err)
+	}
+
+	return nil
+}

--- a/pkg/wireguard/interface_other.go
+++ b/pkg/wireguard/interface_other.go
@@ -1,0 +1,38 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+//go:build !darwin
+
+package wireguard
+
+import (
+	"fmt"
+	"net"
+
+	"github.com/jsimonetti/rtnetlink/rtnl"
+)
+
+const interfaceName = "siderolink"
+
+func linkUp(iface *net.Interface) error {
+	rtnlClient, err := rtnl.Dial(nil)
+	if err != nil {
+		return fmt.Errorf("error initializing netlink client: %w", err)
+	}
+
+	defer rtnlClient.Close() //nolint:errcheck
+
+	return rtnlClient.LinkUp(iface)
+}
+
+func addIPToInterface(iface *net.Interface, ipNet *net.IPNet) error {
+	rtnlClient, err := rtnl.Dial(nil)
+	if err != nil {
+		return fmt.Errorf("error initializing netlink client: %w", err)
+	}
+
+	defer rtnlClient.Close() //nolint:errcheck
+
+	return rtnlClient.AddrAdd(iface, ipNet)
+}

--- a/pkg/wireguard/link_linux.go
+++ b/pkg/wireguard/link_linux.go
@@ -1,0 +1,67 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+//go:build linux
+
+package wireguard
+
+import (
+	"fmt"
+
+	"github.com/jsimonetti/rtnetlink"
+	"golang.org/x/sys/unix"
+)
+
+func createWireguardDevice(name string) (string, error) {
+	c, err := rtnetlink.Dial(nil)
+	if err != nil {
+		return "", fmt.Errorf("error connecting to netlink: %w", err)
+	}
+
+	defer c.Close() //nolint:errcheck
+
+	err = c.Link.New(&rtnetlink.LinkMessage{
+		Family: unix.AF_UNSPEC,
+		Type:   unix.ARPHRD_NONE,
+		Attributes: &rtnetlink.LinkAttributes{
+			Name: name,
+			Type: 65534,
+			Info: &rtnetlink.LinkInfo{
+				Kind: linkKindWireguard,
+			},
+		},
+	})
+	if err != nil {
+		return "", fmt.Errorf("error creating wireguard device: %w", err)
+	}
+
+	return name, nil
+}
+
+func deleteWireguardDevice(name string) error {
+	c, err := rtnetlink.Dial(nil)
+	if err != nil {
+		return err
+	}
+
+	defer c.Close() //nolint:errcheck
+
+	kind, err := c.Link.ListByKind(linkKindWireguard)
+	if err != nil {
+		return err
+	}
+
+	for _, linkMessage := range kind {
+		if linkMessage.Attributes.Name == name {
+			err = c.Link.Delete(linkMessage.Index)
+			if err != nil {
+				return err
+			}
+
+			break
+		}
+	}
+
+	return nil
+}

--- a/pkg/wireguard/link_other.go
+++ b/pkg/wireguard/link_other.go
@@ -1,0 +1,19 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+//go:build !linux
+
+package wireguard
+
+import "fmt"
+
+var ErrUnsupportedOS = fmt.Errorf("unsupported OS")
+
+func createWireguardDevice(_ string) (string, error) {
+	return "", ErrUnsupportedOS
+}
+
+func deleteWireguardDevice(_ string) error {
+	return ErrUnsupportedOS
+}


### PR DESCRIPTION
Siderolink will now attempt to create a native Wireguard device if it is supported by the kernel, instead of a tun device (userspace implementation).

Signed-off-by: Utku Ozdemir <utku.ozdemir@siderolabs.com>