### PR TITLE
fix: ignore 'exist' error on interface managmeent

### DIFF
--- a/pkg/wireguard/interface_other.go
+++ b/pkg/wireguard/interface_other.go
@@ -7,7 +7,9 @@
 package wireguard
 
 import (
+	"errors"
 	"fmt"
+	"io/fs"
 	"net"
 
 	"github.com/jsimonetti/rtnetlink/rtnl"
@@ -34,5 +36,10 @@ func addIPToInterface(iface *net.Interface, ipNet *net.IPNet) error {
 
 	defer rtnlClient.Close() //nolint:errcheck
 
-	return rtnlClient.AddrAdd(iface, ipNet)
+	err = rtnlClient.AddrAdd(iface, ipNet)
+	if err != nil && errors.Is(err, fs.ErrExist) {
+		err = nil
+	}
+
+	return err
 }

--- a/pkg/wireguard/link_linux.go
+++ b/pkg/wireguard/link_linux.go
@@ -7,7 +7,9 @@
 package wireguard
 
 import (
+	"errors"
 	"fmt"
+	"io/fs"
 
 	"github.com/jsimonetti/rtnetlink"
 	"golang.org/x/sys/unix"
@@ -32,7 +34,7 @@ func createWireguardDevice(name string) (string, error) {
 			},
 		},
 	})
-	if err != nil {
+	if err != nil && !errors.Is(err, fs.ErrExist) {
 		return "", fmt.Errorf("error creating wireguard device: %w", err)
 	}
 


### PR DESCRIPTION
This fixes a case when interface is left after a crash and SideroLink
refuses to start after that.

Signed-off-by: Andrey Smirnov <andrey.smirnov@talos-systems.com>