### PR TITLE
fix: include MachineStatusEvent into the list of supported events

### DIFF
--- a/pkg/events/sink.go
+++ b/pkg/events/sink.go
@@ -48,6 +48,7 @@ func (s *Sink) Publish(ctx context.Context, e *events.EventRequest) (*events.Eve
 		&machine.ConfigLoadErrorEvent{},
 		&machine.ConfigValidationErrorEvent{},
 		&machine.AddressEvent{},
+		&machine.MachineStatusEvent{},
 	} {
 		if typeURL == "type.googleapis.com/"+string(eventType.ProtoReflect().Descriptor().FullName()) {
 			msg = eventType


### PR DESCRIPTION
This is new Talos 1.2.0 event.

Signed-off-by: Andrey Smirnov <andrey.smirnov@talos-systems.com>