### PR TITLE
feat: move actual logic into the `agent` package

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,6 +1,6 @@
 # THIS FILE WAS AUTOMATICALLY GENERATED, PLEASE DO NOT EDIT.
 #
-# Generated on 2024-02-29T11:57:03Z by kres latest.
+# Generated on 2024-03-20T20:16:10Z by kres latest.
 
 name: default
 concurrency:
@@ -31,7 +31,7 @@ jobs:
     if: (!startsWith(github.head_ref, 'renovate/') && !startsWith(github.head_ref, 'dependabot/'))
     services:
       buildkitd:
-        image: moby/buildkit:v0.12.5
+        image: moby/buildkit:v0.13.1
         options: --privileged
         ports:
           - 1234:1234
@@ -48,8 +48,8 @@ jobs:
         uses: docker/setup-buildx-action@v3
         with:
           driver: remote
-          endpoint: tcp://localhost:1234
-        timeout-minutes: 1
+          endpoint: tcp://127.0.0.1:1234
+        timeout-minutes: 10
       - name: base
         run: |
           make base

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,21 +1,20 @@
 # THIS FILE WAS AUTOMATICALLY GENERATED, PLEASE DO NOT EDIT.
 #
-# Generated on 2024-02-29T11:57:03Z by kres latest.
+# Generated on 2024-03-20T20:16:10Z by kres latest.
 
 # options for analysis running
 run:
   timeout: 10m
   issues-exit-code: 1
   tests: true
-  build-tags: []
-  skip-dirs: []
-  skip-dirs-use-default: true
-  skip-files: []
+  build-tags: [ ]
   modules-download-mode: readonly
 
 # output configuration options
 output:
-  format: colored-line-number
+  formats:
+  - format: colored-line-number
+    path: stdout
   print-issued-lines: true
   print-linter-name: true
   uniq-by-line: true
@@ -32,54 +31,38 @@ linters-settings:
     check-blank: true
   exhaustive:
     default-signifies-exhaustive: false
-  funlen:
-    lines: 60
-    statements: 40
   gci:
-    local-prefixes: github.com/siderolabs/siderolink/
+    sections:
+      - standard # Standard section: captures all standard packages.
+      - default # Default section: contains all imports that could not be matched to another section type.
+      - prefix(github.com/siderolabs/siderolink/) # Custom section: groups all imports with the specified Prefix.
   gocognit:
     min-complexity: 30
-  ireturn:
-    allow:
-      - anon
-      - error
-      - empty
-      - stdlib
-      - github.com\/talos-systems\/kres\/internal\/dag.Node
   nestif:
     min-complexity: 5
   goconst:
     min-len: 3
     min-occurrences: 3
   gocritic:
-    disabled-checks: []
+    disabled-checks: [ ]
   gocyclo:
     min-complexity: 20
   godot:
-    check-all: false
-  godox:
-    keywords: # default keywords are TODO, BUG, and FIXME, these can be overwritten by this setting
-      - NOTE
-      - OPTIMIZE # marks code that should be optimized before merging
-      - HACK # marks hack-arounds that should be removed before merging
+    scope: declarations
   gofmt:
     simplify: true
   goimports:
     local-prefixes: github.com/siderolabs/siderolink/
-  golint:
-    min-confidence: 0.8
-  gomnd:
-    settings: {}
-  gomodguard: {}
+  gomodguard: { }
+  gomnd: { }
   govet:
-    check-shadowing: true
     enable-all: true
   lll:
     line-length: 200
     tab-width: 4
   misspell:
     locale: US
-    ignore-words: []
+    ignore-words: [ ]
   nakedret:
     max-func-lines: 30
   prealloc:
@@ -88,16 +71,15 @@ linters-settings:
     for-loops: false # Report preallocation suggestions on for loops, false by default
   nolintlint:
     allow-unused: false
-    allow-leading-space: false
-    allow-no-explanation: []
+    allow-no-explanation: [ ]
     require-explanation: false
     require-specific: true
-  rowserrcheck: {}
-  testpackage: {}
+  rowserrcheck: { }
+  testpackage: { }
   unparam:
     check-exported: false
   unused:
-    check-exported: false
+    local-variables-are-used: false
   whitespace:
     multi-if: false   # Enforces newlines (or comments) after every multi-line if statement
     multi-func: false # Enforces newlines (or comments) after every multi-line function signature
@@ -113,8 +95,8 @@ linters-settings:
   gofumpt:
     extra-rules: false
   cyclop:
-      # the maximal code complexity to report
-      max-complexity: 20
+    # the maximal code complexity to report
+    max-complexity: 20
   #  depguard:
   #    Main:
   #      deny:
@@ -125,48 +107,48 @@ linters:
   disable-all: false
   fast: false
   disable:
-    - exhaustruct
     - exhaustivestruct
+    - exhaustruct
     - forbidigo
     - funlen
-    - gas
     - gochecknoglobals
     - gochecknoinits
     - godox
     - goerr113
     - gomnd
     - gomoddirectives
+    - gosec
+    - inamedparam
     - ireturn
     - nestif
     - nonamedreturns
     - nosnakecase
     - paralleltest
+    - tagalign
     - tagliatelle
     - thelper
     - typecheck
     - varnamelen
     - wrapcheck
     - depguard # Disabled because starting with golangci-lint 1.53.0 it doesn't allow denylist alone anymore
-    - tagalign
-    - inamedparam
     - testifylint # complains about our assert recorder and has a number of false positives for assert.Greater(t, thing, 1)
     - protogetter # complains about us using Value field on typed spec, instead of GetValue which has a different signature
     - perfsprint # complains about us using fmt.Sprintf in non-performance critical code, updating just kres took too long
     # abandoned linters for which golangci shows the warning that the repo is archived by the owner
+    - deadcode
+    - golint
+    - ifshort
     - interfacer
     - maligned
-    - golint
     - scopelint
-    - varcheck
-    - deadcode
     - structcheck
-    - ifshort
+    - varcheck
     # disabled as it seems to be broken - goes into imported libraries and reports issues there
     - musttag
 
 issues:
-  exclude: []
-  exclude-rules: []
+  exclude: [ ]
+  exclude-rules: [ ]
   exclude-use-default: false
   exclude-case-sensitive: false
   max-issues-per-linter: 10

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,12 +2,12 @@
 
 # THIS FILE WAS AUTOMATICALLY GENERATED, PLEASE DO NOT EDIT.
 #
-# Generated on 2024-03-10T14:36:55Z by kres latest.
+# Generated on 2024-03-20T20:16:10Z by kres latest.
 
 ARG TOOLCHAIN
 
 # runs markdownlint
-FROM docker.io/node:21.6.2-alpine3.19 AS lint-markdown
+FROM docker.io/node:21.7.1-alpine3.19 AS lint-markdown
 WORKDIR /src
 RUN npm i -g markdownlint-cli@0.39.0
 RUN npm i sentences-per-line@0.2.1
@@ -99,6 +99,7 @@ FROM base AS lint-golangci-lint
 WORKDIR /src
 COPY .golangci.yml .
 ENV GOGC 50
+RUN golangci-lint config verify --config .golangci.yml
 RUN --mount=type=cache,target=/root/.cache/go-build --mount=type=cache,target=/root/.cache/golangci-lint --mount=type=cache,target=/go/pkg golangci-lint run --config .golangci.yml
 
 # runs govulncheck

--- a/Makefile
+++ b/Makefile
@@ -1,11 +1,11 @@
 # THIS FILE WAS AUTOMATICALLY GENERATED, PLEASE DO NOT EDIT.
 #
-# Generated on 2024-03-07T11:10:45Z by kres latest.
+# Generated on 2024-03-20T20:16:10Z by kres latest.
 
 # common variables
 
 SHA := $(shell git describe --match=none --always --abbrev=8 --dirty)
-TAG := $(shell git describe --tag --always --dirty)
+TAG := $(shell git describe --tag --always --dirty --match v[0-9]\*)
 ABBREV_TAG := $(shell git describe --tags >/dev/null 2>/dev/null && git describe --tag --always --match v[0-9]\* --abbrev=0 || echo 'undefined')
 BRANCH := $(shell git rev-parse --abbrev-ref HEAD)
 ARTIFACTS := _out
@@ -19,7 +19,7 @@ GRPC_GO_VERSION ?= 1.3.0
 GRPC_GATEWAY_VERSION ?= 2.19.1
 VTPROTOBUF_VERSION ?= 0.6.0
 DEEPCOPY_VERSION ?= v0.5.6
-GOLANGCILINT_VERSION ?= v1.56.2
+GOLANGCILINT_VERSION ?= v1.57.0
 GOFUMPT_VERSION ?= v0.6.0
 GO_VERSION ?= 1.22.1
 GOIMPORTS_VERSION ?= v0.19.0

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -7,9 +7,7 @@ package server
 
 import (
 	"context"
-	"crypto/rand"
 	"fmt"
-	"io"
 	"net"
 	"net/netip"
 
@@ -31,11 +29,16 @@ type Server struct {
 	cfg     Config
 }
 
+// NodeProvisioner is an interface that provides the node ip and prefix.
+type NodeProvisioner interface {
+	NodePrefix(nodeUUID string, talosVersion string) (netip.Prefix, error)
+}
+
 // Config configures the server.
 //
 //nolint:govet
 type Config struct {
-	NodePrefix      netip.Prefix
+	NodeProvisioner NodeProvisioner
 	ServerAddress   netip.Addr
 	ServerEndpoint  netip.AddrPort
 	VirtualPrefix   netip.Prefix
@@ -59,25 +62,25 @@ func (srv *Server) EventCh() <-chan wireguard.PeerEvent {
 
 // Provision the SideroLink.
 func (srv *Server) Provision(_ context.Context, req *pb.ProvisionRequest) (*pb.ProvisionResponse, error) {
-	if srv.cfg.JoinToken != "" && (req.JoinToken == nil || *req.JoinToken != srv.cfg.JoinToken) {
+	if srv.cfg.JoinToken != "" && req.GetJoinToken() != srv.cfg.JoinToken {
 		return nil, status.Error(codes.PermissionDenied, "invalid join token")
 	}
 
 	// generated random address for the node
-	nodeAddress, err := generateRandomNodeAddr(srv.cfg.NodePrefix)
+	nodeAddress, err := srv.cfg.NodeProvisioner.NodePrefix(req.GetNodeUuid(), req.GetTalosVersion())
 	if err != nil {
 		return nil, status.Error(codes.Internal, fmt.Sprintf("error generating node address: %s", err))
 	}
 
-	pubKey, err := wgtypes.ParseKey(req.NodePublicKey)
+	pubKey, err := wgtypes.ParseKey(req.GetNodePublicKey())
 	if err != nil {
 		return nil, status.Error(codes.InvalidArgument, fmt.Sprintf("error parsing Wireguard key: %s", err))
 	}
 
 	var virtualNode netip.Prefix
 
-	if req.WireguardOverGrpc != nil && *req.WireguardOverGrpc {
-		virtualNode, err = generateRandomNodeAddr(srv.cfg.VirtualPrefix)
+	if req.GetWireguardOverGrpc() {
+		virtualNode, err = wireguard.GenerateRandomNodeAddr(srv.cfg.VirtualPrefix)
 		if err != nil {
 			return nil, status.Error(codes.Internal, fmt.Sprintf("error generating tunnel endpoint: %s", err))
 		}
@@ -120,18 +123,4 @@ func (srv *Server) Provision(_ context.Context, req *pb.ProvisionRequest) (*pb.P
 		ServerAddress:     srv.cfg.ServerAddress.String(),
 		GrpcPeerAddrPort:  grpcPeerAddrPort,
 	}, nil
-}
-
-func generateRandomNodeAddr(prefix netip.Prefix) (netip.Prefix, error) {
-	raw := prefix.Addr().As16()
-	salt := make([]byte, 8)
-
-	_, err := io.ReadFull(rand.Reader, salt)
-	if err != nil {
-		return netip.Prefix{}, err
-	}
-
-	copy(raw[8:], salt)
-
-	return netip.PrefixFrom(netip.AddrFrom16(raw), prefix.Bits()), nil
 }

--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -1,0 +1,129 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+// Package agent provides the main entrypoint for the agent.
+package agent
+
+import (
+	"context"
+	"fmt"
+	"net/netip"
+	"strings"
+
+	"github.com/google/uuid"
+	"go.uber.org/zap"
+	"golang.org/x/sync/errgroup"
+
+	"github.com/siderolabs/siderolink/pkg/wireguard"
+)
+
+// Config is the configuration for the agent.
+//
+//nolint:govet
+type Config struct {
+	WireguardEndpoint string   // WireguardEndpoint is the endpoint for the Wireguard server.
+	APIEndpoint       string   // APIEndpoint is the gRPC endpoint for the SideroLink API.
+	JoinToken         string   // JoinToken is the join token for the SideroLink API.
+	ForceUserspace    bool     // ForceUserspace forces the usage of the userspace UDP device for Wireguard.
+	SinkEndpoint      string   // SinkEndpoint is the gRPC endpoint for the event sink.
+	LogEndpoint       string   // LogEndpoint is the TCP log receiver endpoint.
+	UUIDIPv6Pairs     []string // UUIDIPv6Pairs is a list of UUIDs=IPv6 addrs for the nodes.
+}
+
+// Run runs the agent. [wireguard.PeerHandler] can be nil.
+func Run(ctx context.Context, cfg Config, peerHandler wireguard.PeerHandler, logger *zap.Logger) error {
+	eg, ctx := errgroup.WithContext(ctx)
+
+	var normalExit bool
+
+	defer func() {
+		if normalExit {
+			return
+		}
+
+		if waitErr := eg.Wait(); waitErr != nil {
+			logger.Error("Wait() failed", zap.Error(waitErr))
+		}
+	}()
+
+	logger.Info("starting agent",
+		zap.String("wireguard_endpoint", cfg.WireguardEndpoint),
+		zap.String("api_endpoint", cfg.APIEndpoint),
+		zap.String("sink_endpoint", cfg.SinkEndpoint),
+		zap.String("log_endpoint", cfg.LogEndpoint),
+		zap.Bool("force_userspace", cfg.ForceUserspace),
+	)
+
+	runErr := run(ctx, cfg, peerHandler, eg, logger)
+	waitErr := eg.Wait()
+
+	normalExit = true
+
+	if waitErr != nil {
+		if runErr == nil {
+			return waitErr
+		}
+
+		return fmt.Errorf("%w; also Wait() failed with: %w", runErr, waitErr)
+	}
+
+	return runErr
+}
+
+func run(ctx context.Context, cfg Config, peerHandler wireguard.PeerHandler, eg *errgroup.Group, logger *zap.Logger) (runErr error) {
+	bindPairs, err := parsePairs(cfg.UUIDIPv6Pairs)
+	if err != nil {
+		return err
+	}
+
+	linkCfg := sideroLinkConfig{
+		wireguardEndpoint: cfg.WireguardEndpoint,
+		apiEndpoint:       cfg.APIEndpoint,
+		joinToken:         cfg.JoinToken,
+		forceUserspace:    cfg.ForceUserspace,
+		predefinedPairs:   bindPairs,
+	}
+
+	if err := sideroLink(ctx, eg, linkCfg, peerHandler, logger); err != nil {
+		return fmt.Errorf("SideroLink: %w", err)
+	}
+
+	if err := eventSink(ctx, cfg.SinkEndpoint, eg); err != nil {
+		return fmt.Errorf("event sink: %w", err)
+	}
+
+	if err := logReceiver(ctx, cfg.LogEndpoint, eg, logger); err != nil {
+		return fmt.Errorf("log receiver: %w", err)
+	}
+
+	return nil
+}
+
+func parsePairs(pairs []string) ([]bindUUIDtoIPv6, error) {
+	bindPairs := make([]bindUUIDtoIPv6, 0, len(pairs))
+
+	for _, pair := range pairs {
+		uuidStr, addr, found := strings.Cut(pair, "=")
+		if !found {
+			return nil, fmt.Errorf("invalid UUID=IPv6 pair: %s", pair)
+		}
+
+		_, err := uuid.Parse(uuidStr)
+		if err != nil {
+			return nil, fmt.Errorf("invalid UUID: %s", uuidStr)
+		}
+
+		parseAddr, err := netip.ParseAddr(addr)
+		if err != nil {
+			return nil, fmt.Errorf("invalid IPv6 address: %s", addr)
+		}
+
+		bindPairs = append(bindPairs, bindUUIDtoIPv6{
+			UUID: uuidStr,
+			IPv6: parseAddr,
+		})
+	}
+
+	return bindPairs, nil
+}

--- a/pkg/logreceiver/server.go
+++ b/pkg/logreceiver/server.go
@@ -28,12 +28,12 @@ type Server struct {
 type Handler func(srcAddress netip.Addr, msg map[string]interface{})
 
 // NewServer initializes new Server.
-func NewServer(logger *zap.Logger, listener net.Listener, handler Handler) (*Server, error) {
+func NewServer(logger *zap.Logger, listener net.Listener, handler Handler) *Server {
 	return &Server{
 		listener: listener,
 		logger:   logger,
 		handler:  handler,
-	}, nil
+	}
 }
 
 // Serve runs the TCP server loop.

--- a/pkg/wgtunnel/wgbind/server.go
+++ b/pkg/wgtunnel/wgbind/server.go
@@ -186,7 +186,7 @@ func wrapWithDebugLoggerSlow(l *zap.Logger, fns []conn.ReceiveFunc) []conn.Recei
 
 			l.Debug("non GRPC ReceiveFunc returned", zap.Int("n", n), zap.Int("i", i))
 
-			for j := 0; j < n; j++ {
+			for j := range n {
 				l.Debug(
 					"non GRPC ReceiveFunc packet",
 					zap.Int("size", sizes[j]),

--- a/pkg/wireguard/address.go
+++ b/pkg/wireguard/address.go
@@ -5,7 +5,9 @@
 package wireguard
 
 import (
+	"crypto/rand"
 	"crypto/sha256"
+	"io"
 	"net/netip"
 )
 
@@ -39,4 +41,19 @@ func networkPrefix(installationID string, suffix byte) netip.Prefix {
 	prefixData[7] = suffix
 
 	return netip.PrefixFrom(netip.AddrFrom16(prefixData), 64).Masked()
+}
+
+// GenerateRandomNodeAddr generates a random node address within the last 8 bytes of the given prefix.
+func GenerateRandomNodeAddr(prefix netip.Prefix) (netip.Prefix, error) {
+	raw := prefix.Addr().As16()
+	salt := make([]byte, 8)
+
+	_, err := io.ReadFull(rand.Reader, salt)
+	if err != nil {
+		return netip.Prefix{}, err
+	}
+
+	copy(raw[8:], salt)
+
+	return netip.PrefixFrom(netip.AddrFrom16(raw), prefix.Bits()), nil
 }


### PR DESCRIPTION
This change makes `github.com/siderolabs/siderolink/cmd/siderolink-agent` importable as `github.com/siderolabs/siderolink/pkg/agent`.

It also contains the ability to "pre-bind" specific UUIDs to the specific IPv6s.