### PR TITLE
fix: clean up device on failure

### DIFF
--- a/pkg/wireguard/link_linux.go
+++ b/pkg/wireguard/link_linux.go
@@ -38,20 +38,48 @@ func createWireguardDevice(name string) (string, error) {
 		},
 	})
 	if err != nil && !errors.Is(err, fs.ErrExist) {
-		return "", fmt.Errorf("error ating wireguard device: %w", err)
+		return "", fmt.Errorf("error creating wireguard device: %w", err)
 	}
 
-	for _, path := range []string{
-		fmt.Sprintf("/proc/sys/net/ipv4/conf/%s/forwarding", name),
-		fmt.Sprintf("/proc/sys/net/ipv6/conf/%s/forwarding", name),
-	} {
-		if err = os.MkdirAll(filepath.Dir(path), 0o644); err != nil {
-			return "", err
+	allLinks, err := c.Link.List()
+	if err != nil {
+		return "", fmt.Errorf("error listing links: %w", err)
+	}
+
+	var linkIdx uint32
+
+	for _, linkMessage := range allLinks {
+		if linkMessage.Attributes.Name == name {
+			linkIdx = linkMessage.Index
+
+			break
+		}
+	}
+
+	if linkIdx == 0 {
+		return "", fmt.Errorf("wireguard device %s not found", name)
+	}
+
+	if err := func() error {
+		for _, path := range []string{
+			fmt.Sprintf("/proc/sys/net/ipv4/conf/%s/forwarding", name),
+			fmt.Sprintf("/proc/sys/net/ipv6/conf/%s/forwarding", name),
+		} {
+			if err := os.MkdirAll(filepath.Dir(path), 0o644); err != nil {
+				return err
+			}
+
+			if err := os.WriteFile(path, []byte("0\n"), 0o644); err != nil {
+				return err
+			}
 		}
 
-		if err = os.WriteFile(path, []byte("0\n"), 0o644); err != nil {
-			return "", err
-		}
+		return nil
+	}(); err != nil {
+		// try to clean up the created link
+		c.Link.Delete(linkIdx) //nolint:errcheck
+
+		return "", fmt.Errorf("error writing sysctl files: %w", err)
 	}
 
 	return name, nil


### PR DESCRIPTION
If we created a wireguard device, but failed to write sysctls, we should destroy the device, as otherwise userspace tun setup would fail, as the link with the name already exists.